### PR TITLE
chore: contributor guide, Makefile, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Lint, Typecheck, Test
+    runs-on: ubuntu-latest
+    env:
+      PYTHONUNBUFFERED: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Poetry
+        uses: pipxproject/action-install-pipx@v1
+
+      - name: Install Poetry via pipx
+        run: pipx install poetry==1.8.3
+
+      - name: Configure Poetry
+        run: |
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+
+      - name: Cache virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install --with dev --no-interaction --no-ansi
+
+      - name: Ruff (lint)
+        run: poetry run ruff check .
+
+      - name: Black (format check)
+        run: poetry run black --check .
+
+      - name: mypy (type check)
+        run: poetry run mypy
+
+      - name: Pytest
+        run: poetry run pytest -q
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `app/`: service code (FastAPI, adapters, core, db, llm, observability). Entrypoint: `app/main.py` (`app` ASGI).
+- `tests/`: mirrors `app/` by domain (e.g., `tests/core/test_*.py`).
+- `configs/`: runtime YAML defaults (`configs/default.yaml`).
+- `alembic/`: DB migrations (`alembic.ini`, `alembic/versions`).
+- `specs/`: planning docs for phased delivery.
+
+## Build, Test, and Development Commands
+- Install: `poetry env use 3.13 && poetry install`.
+- Run API (dev): `poetry run uvicorn app.main:app --reload`.
+- Tests: `poetry run pytest` (async enabled via `pytest-asyncio`).
+- Coverage (optional): `poetry run pytest --cov=app`.
+- Lint/format: `poetry run ruff check --fix && poetry run black .`.
+- Type-check: `poetry run mypy`.
+- Migrate DB: `ALEMBIC_SQLALCHEMY_URL=sqlite:///dev.db poetry run alembic upgrade head`.
+ - Pre-commit (optional): `pre-commit install && pre-commit run -a`.
+
+## Coding Style & Naming Conventions
+- Python 3.13, 4-space indentation, max line length 100 (Black/Ruff).
+- Use type hints everywhere; mypy is strict (`disallow_untyped_defs = true`).
+- Names: modules/functions `snake_case`, classes `PascalCase`, constants `UPPER_SNAKE`.
+- Imports: first-party package is `app` (Ruff isort config enforces order).
+
+## Testing Guidelines
+- Framework: `pytest` + `pytest-asyncio`; HTTP via `httpx.AsyncClient` with `asgi-lifespan`.
+- Place tests under `tests/` using `test_*.py`; mirror `app/` structure.
+- Mark async tests with `@pytest.mark.asyncio`.
+- Use fixtures from `tests/conftest.py` (`app`, `client`).
+
+## Migrations & Database
+- Alembic manages schema; initial revision `0001_initial` builds from `app.models.metadata`.
+- Local dev: SQLite is fine; set `ALEMBIC_SQLALCHEMY_URL` or `DATABASE_URL`.
+- In production, run Alembic migrations rather than `metadata.create_all()`.
+
+## Commit & Pull Request Guidelines
+- Commits: imperative, scoped messages (e.g., `feat(core): add orchestrator`); keep changes focused.
+ - PRs: include summary, linked issue/spec, test coverage, and local run steps. Add screenshots for API changes when useful (e.g., curl command + JSON response).
+
+## Security & Configuration Tips
+- Config: defaults in `configs/default.yaml`. Override via `SH_CONFIG_FILE` or env (e.g., `SH_SEARCH__PROVIDER=google`).
+- Secrets via env only: `SH_SERPER_KEY`, `SH_GOOGLE_API_KEY`, `SH_GOOGLE_CSE_ID`, `SH_BRAVE_KEY`, `OPENAI_API_KEY`.
+- Prefer `uvicorn` locally; do not log secrets. Validate secrets in `prod` or when `SH_VALIDATE_SECRETS=true`.

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help: ## Show this help.
 
 install: ## Set Python 3.13 and install deps via Poetry
 	$(PY) env use 3.13
-	$(PY) install
+	$(PY) install --with dev
 
 run: ## Run the API locally with reload (uvicorn)
 	$(PY) run uvicorn app.main:app --reload --host 0.0.0.0 --port $(PORT)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Default variables
+PY?=poetry
+PORT?=8000
+DB_URL?=sqlite:///dev.db
+
+.PHONY: help install run test coverage lint format typecheck migrate precommit-install precommit
+.DEFAULT_GOAL := help
+
+help: ## Show this help.
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+
+install: ## Set Python 3.13 and install deps via Poetry
+	$(PY) env use 3.13
+	$(PY) install
+
+run: ## Run the API locally with reload (uvicorn)
+	$(PY) run uvicorn app.main:app --reload --host 0.0.0.0 --port $(PORT)
+
+test: ## Run tests (pytest)
+	$(PY) run pytest
+
+coverage: ## Run tests with coverage report
+	$(PY) run pytest --cov=app
+
+lint: ## Lint the code (Ruff) without fixing
+	$(PY) run ruff check .
+
+format: ## Auto-fix lint issues and format code (Ruff + Black)
+	$(PY) run ruff check --fix .
+	$(PY) run black .
+
+typecheck: ## Type-check with mypy
+	$(PY) run mypy
+
+migrate: ## Apply DB migrations to head (set DB_URL or use default SQLite)
+	ALEMBIC_SQLALCHEMY_URL=$(DB_URL) $(PY) run alembic upgrade head
+
+precommit-install: ## Install pre-commit hooks (requires pre-commit in env)
+	$(PY) run pre-commit install
+
+precommit: ## Run all pre-commit hooks against all files (optional)
+	$(PY) run pre-commit run -a
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Source Harvester Microservice
 
+[![CI](https://github.com/hopchouinard/1-source_harvester/actions/workflows/ci.yml/badge.svg)](https://github.com/hopchouinard/1-source_harvester/actions/workflows/ci.yml)
+
 Minimal FastAPI microservice scaffolding for the Source Harvester, following the implementation plan in `specs/SH_Microservice_Plan.md`.
 
 - Runtime: Python 3.13
@@ -16,10 +18,33 @@ poetry run pytest
 
 This repository is being implemented phase-by-phase per the plan. Current status: Phase A — Scaffolding.
 
-Configuration (Phase B)
+## Quickstart
+- Install deps and set Python 3.13: `make install`
+- Run the API with reload: `make run` (defaults to port 8000)
+- Run tests: `make test`
+
+Then visit `http://localhost:8000/healthz` or try:
+
+```
+curl -s http://localhost:8000/healthz | jq
+```
+
+## Makefile Usage
+- `make install` — setup Poetry env and install deps
+- `make run` — start `uvicorn app.main:app` with `--reload`
+- `make test` — run `pytest`
+- `make coverage` — run tests with coverage
+- `make lint` / `make format` — Ruff check/fix and Black format
+- `make typecheck` — mypy
+- `make migrate DB_URL=sqlite:///dev.db` — apply Alembic migrations
+
+## Configuration (Phase B)
 - YAML: `configs/default.yaml` is loaded by default. Override via `SH_CONFIG_FILE=/path/to/config.yaml`.
 - Env overrides: use nested variables, e.g. `SH_SEARCH__PROVIDER=google`, `SH_LLM__PROVIDER=openai`.
 - Secrets (env only):
   - Providers: `SH_SERPER_KEY`, `SH_GOOGLE_API_KEY`, `SH_GOOGLE_CSE_ID`, `SH_BRAVE_KEY`
   - LLM: `OPENAI_API_KEY` (or `SH_OPENAI_API_KEY`)
 - Secret enforcement: enforced in `prod` or when `SH_VALIDATE_SECRETS=true`.
+
+## CI
+- GitHub Actions runs lint (Ruff), format check (Black), type-check (mypy), and tests (pytest) on pushes and PRs. See the CI badge above for status.


### PR DESCRIPTION
This PR adds contributor documentation, a Makefile for common dev tasks, and CI.\n\nChanges\n- AGENTS.md: contributor guide tailored to this repo (structure, commands, style, tests, migrations, commits/PRs, security).\n- Makefile: install/run/test/coverage/lint/format/typecheck/migrate/precommit targets.\n- CI: GitHub Actions workflow running Ruff, Black check, mypy, and pytest on pushes/PRs.\n- README: CI badge, Quickstart, Makefile usage, and CI section.\n\nNotes\n- Default DB URL for migrations is `sqlite:///dev.db`. Override with `DB_URL` in Make target.\n- CI uses Python 3.13 and Poetry 1.8.3 with in-project virtualenv.\n